### PR TITLE
add new endpoint for permanent public url (no expiration in url)

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -2,6 +2,7 @@ require 'digest/md5'
 
 class MediaController < ApplicationController
 
+  # 'show' will validate tokenized-url and redirect to real storage url, with expiration.
   def show
     version = nil
     asset = params[:class].camelize.constantize.find(params[:id])
@@ -13,5 +14,13 @@ class MediaController < ApplicationController
       head 401
     end
   end
+
+  # 'permanent' will always redirect to tokenized url (handled by 'show')
+  def permanent
+    asset = params[:class].camelize.constantize.find(params[:idhex].to_i(16))
+    version = params[:extension] ? params[:extension].to_sym : nil
+    url = asset.public_url({:extension => version})
+    redirect_to url
+  end 
 
 end

--- a/app/models/image_file.rb
+++ b/app/models/image_file.rb
@@ -1,5 +1,6 @@
 class ImageFile < ActiveRecord::Base
 
+  include PublicAsset
   include FileStorage
 
   attr_accessible :file, :original_file_url, :storage_id, :is_uploaded, :remote_file_url, :imageable_id, :imageable_type

--- a/app/models/public_asset.rb
+++ b/app/models/public_asset.rb
@@ -9,6 +9,16 @@ module PublicAsset
     include Rails.application.routes.url_helpers  
   end
 
+  # returns "permanent" URL suitable for use when content is being pre-rendered/cached.
+  def permanent_public_url
+    opts = set_defaults({})
+    ext  = opts[:extension]
+    # 'id' is slightly obfuscated as hexadecimal string
+    url = root_url + ["media",opts[:class],opts[:id].to_i.to_s(16),opts[:name]].join('/')
+    url += ".#{ext}" unless ext.blank?
+    url
+  end
+
   # validates token with or without expires option
   def public_url_token(options={})
     o = set_defaults(options)

--- a/app/views/api/v1/audio_files/_audio_file.json.rabl
+++ b/app/views/api/v1/audio_files/_audio_file.json.rabl
@@ -1,5 +1,5 @@
 attributes :id, :filename, :transcoded_at, :duration, :current_status
-attributes :urls => :url
+attributes :urls => :permanent_public_url
 attributes :transcript_type
 attributes :has_premium_transcribe_task_in_progress? => :premium_in_progress
 node :premium_retail_cost do |af|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ PopUpArchive::Application.routes.draw do
   end
 
   get 'media/:token/:expires/:use/:class/:id/:name.:extension', controller: 'media', action: 'show', constraints: {name: /[^\/]+/}
+  get 'media/:class/:idhex/:name.:extension', controller: 'media', action: 'permanent', constraints: {name: /[^\/]+/}
   
   get 'embed_player/:name/:file_id/:item_id/:collection_id', to: 'embed_player', action: 'show'
 


### PR DESCRIPTION
Not sure this is a good idea, but I coded this up in a fit of pique about a month ago and didn't want it to get lost. This basically adds a new, tidy, permanent url for public assets.