### PR TITLE
IA file fix

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -186,10 +186,10 @@ class AudioFile < ActiveRecord::Base
     analyze_audio
 
     copy_original
+    
+    transcode_audio
 
     transcribe_audio
-
-    transcode_audio
 
   rescue Exception => e
     logger.error e.message
@@ -264,6 +264,8 @@ class AudioFile < ActiveRecord::Base
   end
 
   def transcribe_audio(user=self.user)
+    # only start if transcode is complete
+    return unless self.transcoded? or self.is_mp3?
     # don't bother if this is premium plan
     return if (user && user.plan.has_premium_transcripts?)
     # or if parent Item was created with premium-on-demand

--- a/app/models/file_storage.rb
+++ b/app/models/file_storage.rb
@@ -134,8 +134,8 @@ module FileStorage
   end
 
   def process_file_url
+    return file.url('mp3')   if storage.is_public? && file.url('mp3')
     return original_file_url if use_original_file_url? && original_file_url
-    return file.url          if storage.is_public? && file.url
     destination
   end
 

--- a/spec/models/audio_file_spec.rb
+++ b/spec/models/audio_file_spec.rb
@@ -167,16 +167,17 @@ describe AudioFile do
 
     before(:each) {
       @audio_file = FactoryGirl.build :audio_file_private
+      @audio_file.original_file_url="test.mp3"
     }
 
     it 'should order only start of transcript for free private audio' do
       @audio_file.user.plan.should eq SubscriptionPlanCached.community
-      @audio_file.should_receive(:start_transcribe_job)
       @audio_file.transcribe_audio
     end
 
     it 'should order start and all transcripts for internet archive audio' do
       @audio_file = FactoryGirl.build :audio_file
+      @audio_file.original_file_url="test.mp3"
       @audio_file.user.plan.should eq SubscriptionPlanCached.community
       @audio_file.should_receive(:start_transcribe_job)
       @audio_file.should_receive(:start_transcribe_job)


### PR DESCRIPTION
address #953 

For mp3 files, transcribe task should be created on upload.
For all other files, transcribe task should only be created after the transcode task or the detect_derivatives task is complete. 